### PR TITLE
log() callback

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -77,7 +77,7 @@ var Loggly = exports.Loggly = function (options) {
 util.inherits(Loggly, winston.Transport);
 
 //
-// Define a getter so that `winston.transports.Loggly` 
+// Define a getter so that `winston.transports.Loggly`
 // is available and thus backwards compatible.
 //
 winston.transports.Loggly = Loggly;
@@ -111,14 +111,14 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     // If we haven't gotten the input token yet
     // add this message to the log buffer.
     //
-    this.logBuffer.push(message);
+    this.logBuffer.push([message, callback]);
   }
   else if (this.ready && this.logBuffer.length > 0) {
     //
     // Otherwise if we have buffered messages
     // add this message to the buffer and flush them.
     //
-    this.logBuffer.push(message);
+    this.logBuffer.push([message, callback]);
     this.flush();
   }
   else {
@@ -126,11 +126,10 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     // Otherwise just log the message as normal
     //
     this.client.log(this.inputToken, message, function () {
+      if (callback) callback(null, true);
       self.emit('logged');
     });
   }
-
-  callback(null, true);
 };
 
 //
@@ -141,12 +140,18 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
 Loggly.prototype.flush = function () {
   var self = this;
 
-  function logMsg (msg, next) {
+  function logMsg (item, next) {
+    var msg = item[0],
+        callback = item[1];
+
     self.client.log(self.inputToken, msg, function (err) {
       if (err) {
+        if (callback) callback(err, false);
         self.emit('error', err);
+        return next();
       }
 
+      if (callback) callback(null, true);
       next();
     });
   }


### PR DESCRIPTION
This will execute the `log` method's callback correctly.
