### PR TITLE
Modified search functionality for loggly GEN2

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -172,13 +172,12 @@ Loggly.prototype.stream = function(options) {
 
 Loggly.prototype.query = function (options, callback) {
   var self = this,
-      meta = this.extractMeta(options),
       context = this.extractContext(options);
+      options = this.loglify(options);
+      options = this.extend(options, context);
 
   this.client
-    .search(this.loglify(options))
-    .context(context)
-    .meta(meta)
+    .search(options)
     .run(function (err, logs) {
       return err
         ? callback(err)
@@ -217,12 +216,13 @@ Loggly.prototype.formatResults = function (results, options) {
 Loggly.prototype.extractContext = function (obj) {
   var context = {};
 
-  ['rows',
-   'start',
+  
+   ['start',
    'from',
    'until',
    'order',
    'callback',
+   'size',
    'format',
    'fields'].forEach(function (key) {
     if (obj[key]) {
@@ -237,29 +237,11 @@ Loggly.prototype.extractContext = function (obj) {
 
   context.from  = context.from  || '-1d';
   context.until = context.until || 'now';
-  context.rows  = context.rows  || 50;
+  context.size  = context.size  || 50;
 
   return context;
 };
 
-//
-// ### function extractContext (obj)
-// #### @obj {Object} Options has to extract Loggly 'meta' properties from
-// Returns a separate object containing all Loggly 'meta' properties in
-// the object supplied and removes those properties from the original object.
-// [See Loggly Search Language Guide](http://wiki.loggly.com/searchguide)
-//
-Loggly.prototype.extractMeta = function (obj) {
-  var meta = {};
-  ['ip', 'address', 'device', 'inputname', 'inputid'].forEach(function (key) {
-    if (obj[key]) {
-      meta[key] = obj[key];
-      delete obj[key];
-    }
-  });
-
-  return meta;
-};
 
 //
 // ### function loglify (obj)
@@ -273,15 +255,19 @@ Loggly.prototype.loglify = function (obj) {
 
   Object.keys(obj).forEach(function (key) {
     if (key !== 'query') {
-      opts.push('json.' + key + ':' + obj[key]);
+        if (key == 'tag') {
+          opts.push(key + ':' + obj[key]);
+        }
+        else {
+          opts.push('json.' + key + ':' + obj[key]);
+       }
     }
   });
 
   if (obj.query) {
     opts.unshift(obj.query);
   }
-
-  return opts.join(' AND ');
+  return  {'query' : opts.join(' AND ')}
 };
 
 //
@@ -295,12 +281,11 @@ Loggly.prototype.loglify = function (obj) {
 // 3. Input IDs
 //
 Loggly.prototype.sanitizeLogs = function (logs) {
-  logs.context.query = logs.context.query.replace(/\s*inputname\:\w+\s*/ig, '');
-  logs.data.forEach(function (item) {
-    delete item.ip;
-    delete item.inputId;
-    delete item.inputname
-  });
-
   return logs;
 };
+
+Loggly.prototype.extend = function(destination,source) {
+    for (var property in source)
+        destination[property] = source[property];
+    return destination;
+}


### PR DESCRIPTION
Removed Module:
extractMeta - You don't need to manage input/device anymore in loggly gen2.
sanitizeLogs - Critical information such as IP Addresses, Input names not available in data returned from Loggly.

Added 'size' in extractContext module as instead of 'rows', the 'size' field is used for number of rows returned by search.
