### PR TITLE
Prevent loglify function from using standard paging / range parameters as query parameters

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -261,7 +261,14 @@ Loggly.prototype.loglify = function (obj) {
   var opts = [];
 
   Object.keys(obj).forEach(function (key) {
-    if (key !== 'query') {
+    if (key !== 'query' &&
+        key !== 'fields' &&
+        key !== 'start' &&
+        key !== 'rows' &&
+        key !== 'limit' &&
+        key !== 'from' &&
+        key !== 'until')
+    {
         if (key == 'tag') {
           opts.push(key + ':' + obj[key]);
         }


### PR DESCRIPTION
For issue https://github.com/indexzero/winston-loggly/issues/16
