### PR TITLE
Allow setting tags per log statement

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -87,7 +87,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   }
 
   var message = winston.clone(meta || {}),
-      tags    = this.tags || meta.tags,
+      tags    = meta.tags || this.tags,
       self    = this;
 
   message.level = level;


### PR DESCRIPTION
In the original code, "meta.tags" never gets used because this.tags is always set.