### PR TITLE
Serialize Error-typed metadata argument

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -91,8 +91,22 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     msg = ('' + msg).replace(code, '');
   }
 
-  var message = winston.clone(meta || {}),
-      self    = this;
+
+  var self = this;
+  var message;
+  // Error objects do not serialized correctly with node-loggly library
+  // only object or string is supported
+  // sanitize error to plain object to be correctly serialized
+  if(meta instanceof Error){
+    message = {
+        level: level,
+        name: meta.name,
+        message: meta.message,
+        stack: meta.stack
+      };
+  }else{
+    message = winston.clone(meta || {});
+  }
 
   message.level = level;
   message.message = msg;


### PR DESCRIPTION
Serialize Error-typed metadata arguments more correctly to save meaningful fields.