### PR TITLE
Use options to add timestamp into meta on each log

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -55,6 +55,7 @@ var Loggly = exports.Loggly = function (options) {
     tags: tags
   });
 
+  this.timestamp = options.timestamp || false;
   this.stripColors = options.stripColors || false;
 };
 
@@ -85,6 +86,11 @@ Loggly.prototype.name = 'loggly';
 Loggly.prototype.log = function (level, msg, meta, callback) {
   if (this.silent) {
     return callback(null, true);
+  }
+
+  if (this.timestamp && (!meta || !meta.timestamp)) {
+    meta = meta || {};
+    meta.timestamp = (new Date()).toISOString();
   }
 
   if (this.stripColors) {


### PR DESCRIPTION
When logging lots of data into loggly via winston, it became apparent that the events are not received in the order they are logged. To combat this fact, this change adds a timestamp to the meta for each call to log.