### PR TITLE
Add metaKey config option. Fix JSON encoding of meta Error instance.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ The Loggly transport is based on [Nodejitsu's][2] [node-loggly][3] implementatio
 * __tags:__ An array of tags to send to loggly.
 * __isBulk:__ If true, sends messages using bulk url
 * __stripColors:__ Strip color codes from the logs before sending
+* __metaKey:__ If defined, keys from the meta parameter are written to the loggly message under this key rather than at the top level
 
 
 *Metadata:* Logged in suggested [Loggly format][5]

--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -58,6 +58,7 @@ var Loggly = exports.Loggly = function (options) {
 
   this.timestamp = options.timestamp || false;
   this.stripColors = options.stripColors || false;
+  this.metaKey = options.metaKey;
 };
 
 //
@@ -89,20 +90,37 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     return callback(null, true);
   }
 
+  var entry = {};
+
   if (this.timestamp && (!meta || !meta.timestamp)) {
-    meta = meta || {};
-    meta.timestamp = (new Date()).toISOString();
+    entry.timestamp = (new Date()).toISOString();
+  } else {
+    entry.timestamp = meta.timestamp
+    delete meta.timestamp
   }
 
   if (this.stripColors) {
     msg = ('' + msg).replace(code, '');
   }
 
-  var message = winston.clone(meta || {}),
+  var meta = meta ? winston.clone(meta) : undefined,
       self    = this;
 
-  message.level = level;
-  message.message = msg;
+  function copyProperties(src, dest) {
+    Object.getOwnPropertyNames(src).forEach(function(k) {
+      dest[k] = src[k];
+    });
+  }
+
+  if (this.metaKey !== undefined) {
+    entry[this.metaKey] = {};
+    copyProperties(meta, entry[this.metaKey]);
+  } else {
+    copyProperties(meta, entry);
+  }
+
+  entry.level = level;
+  entry.message = msg;
 
   //
   // Helper function for responded to logging.
@@ -113,8 +131,8 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
   }
 
   return meta.tags
-    ? this.client.log(message, meta.tags, logged)
-    : this.client.log(message, logged);
+    ? this.client.log(entry, meta.tags, logged)
+    : this.client.log(entry, logged);
 };
 
 //


### PR DESCRIPTION
Fix #37:
- Write properties of Error instances to JSON 
- Add ability to write meta object keys under a new named property (e.g. `meta`) in the resultant loggly message, rather than at top level (which can conflict when meta contains keys like `message`).