### PR TITLE
fix: decycle circular metadata

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -10,7 +10,8 @@ var events = require('events'),
     loggly = require('loggly'),
     util = require('util'),
     winston = require('winston'),
-    Stream = require('stream').Stream;
+    Stream = require('stream').Stream,
+    cycle = require('cycle');
 
 //
 // Remark: This should be at a higher level.
@@ -99,7 +100,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     msg = ('' + msg).replace(code, '');
   }
 
-  var message = winston.clone(meta || {}),
+  var message = winston.clone(cycle.decycle(meta) || {}),
       self    = this;
 
   message.level = level;

--- a/package.json
+++ b/package.json
@@ -7,15 +7,24 @@
     "type": "git",
     "url": "http://github.com/indexzero/winston-loggly.git"
   },
-  "keywords": ["logging", "sysadmin", "tools"],
+  "keywords": [
+    "logging",
+    "sysadmin",
+    "tools"
+  ],
   "dependencies": {
+    "cycle": "^1.0.3",
     "loggly": "~1.1.0"
   },
   "devDependencies": {
-    "winston": "1.0.x",
-    "vows": "0.8.0"
+    "vows": "0.8.0",
+    "winston": "1.0.x"
   },
   "main": "./lib/winston-loggly",
-  "scripts": { "test": "vows --spec" },
-  "engines": { "node": ">= 0.8.0" }
+  "scripts": {
+    "test": "vows --spec"
+  },
+  "engines": {
+    "node": ">= 0.8.0"
+  }
 }


### PR DESCRIPTION
Previously one of the existing tests broke due to missing decycling.

fixes #54 