### PR TITLE
fix: clone was removed in... Support winston 3

### DIFF
--- a/lib/winston-loggly.js
+++ b/lib/winston-loggly.js
@@ -99,7 +99,7 @@ Loggly.prototype.log = function (level, msg, meta, callback) {
     msg = ('' + msg).replace(code, '');
   }
 
-  var message = winston.clone(meta || {}),
+  var message = Object.assign({}, meta),
       self    = this;
 
   message.level = level;


### PR DESCRIPTION
Added support for winston@3 by fixing error: 
{ clone } was removed in winston@3.0.0